### PR TITLE
Docs: Fix broken semantic-release documentation urls

### DIFF
--- a/packages/mrm-task-semantic-release/Readme.md
+++ b/packages/mrm-task-semantic-release/Readme.md
@@ -21,7 +21,7 @@ See [Mrm docs](https://github.com/sapegin/mrm#usage) for more details.
 
 ### `semanticConfig` (object, optional)
 
-A semantic-release [config object](https://github.com/semantic-release/semantic-release#plugins), will be added to `package.json` as a `release` key.
+A semantic-release [config object](https://semantic-release.gitbooks.io/semantic-release/content/docs/usage/plugins.html#configuration), will be added to `package.json` as a `release` key.
 
 ### `semanticArgs` (string, optional)
 

--- a/packages/mrm-task-semantic-release/index.js
+++ b/packages/mrm-task-semantic-release/index.js
@@ -37,7 +37,7 @@ semantic-release needs to add required auth keys to Travis CI.
 WARNING: Do not agree to update your .travis.yml when asked.
 
 More info:
-https://github.com/semantic-release/semantic-release#setup
+https://semantic-release.gitbooks.io/semantic-release/content/docs/usage/ci-configuration.html#automatic-setup-with-semantic-release-cli
 `
 		);
 	}


### PR DESCRIPTION
Broken link in message https://github.com/sapegin/mrm-tasks/blob/master/packages/mrm-task-semantic-release/index.js#L39-L40
> More info:
> https://github.com/semantic-release/semantic-release#setup

Updated in https://github.com/semantic-release/semantic-release/commit/ed89361d7c55f6aef2c3e010ce592454ca93a837#diff-04c6e90faac2675aa89e2176d2eec7d8L132
And separated to https://github.com/semantic-release/semantic-release/blob/caribou/docs/usage/ci-configuration.md#automatic-setup-with-semantic-release-cli

And in Readme 

semantic-release moved documentation from readme to gitbook: https://github.com/semantic-release/semantic-release/commit/fdb995f77dfdb5689bb149afbb2ee7358d5ddfbc